### PR TITLE
Remove triage component "Core :: Networking: Cookies"

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ In general, we want to:
 
 There are two locations we watch for incoming bugs:
 * [Triage Helper](https://mozilla-necko.github.io/necko-triage/)
-* [Triage Center](https://mozilla.github.io/triage-center/?component=Core%3ANetworking&component=Core%3ANetworking%3A+Cache&component=Core%3ANetworking%3A+Cookies&component=Core%3ANetworking%3A+DNS&component=Core%3ANetworking%3A+Proxy&component=Core%3ANetworking%3A+File&component=Core%3ANetworking%3A+HTTP&component=Core%3ANetworking%3A+JAR&component=Core%3ANetworking%3A+WebSockets)
+* [Triage Center](https://mozilla.github.io/triage-center/?component=Core%3ANetworking&component=Core%3ANetworking%3A+Cache&component=Core%3ANetworking%3A+DNS&component=Core%3ANetworking%3A+Proxy&component=Core%3ANetworking%3A+File&component=Core%3ANetworking%3A+HTTP&component=Core%3ANetworking%3A+JAR&component=Core%3ANetworking%3A+WebSockets)
 
 We use [Bugzilla](https://bugzilla.mozilla.org) to edit the bugs.
 

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
         </ul>
 
         <ul id="triage-center">
-            <a href="https://mozilla.github.io/triage-center/?component=Core%3ADOM%3A+Networking&component=Core%3ANetworking&component=Core%3ANetworking%3A+Cache&component=Core%3ANetworking%3A+Cookies&component=Core%3ANetworking%3A+DNS&component=Core%3ANetworking%3A+Proxy&component=Core%3ANetworking%3A+File&component=Core%3ANetworking%3A+HTTP&component=Core%3ANetworking%3A+JAR&component=Core%3ANetworking%3A+WebSockets"> Triage center </a>
+            <a href="https://mozilla.github.io/triage-center/?component=Core%3ADOM%3A+Networking&component=Core%3ANetworking&component=Core%3ANetworking%3A+Cache&component=Core%3ANetworking%3A+DNS&component=Core%3ANetworking%3A+Proxy&component=Core%3ANetworking%3A+File&component=Core%3ANetworking%3A+HTTP&component=Core%3ANetworking%3A+JAR&component=Core%3ANetworking%3A+WebSockets"> Triage center </a>
         </ul>
         <div id="necko-triage-root">
             <ul id="necko-triage-tabs" class="tab-menu"></ul>

--- a/necko-triage.js
+++ b/necko-triage.js
@@ -6,7 +6,6 @@ NeckoTriage.prototype.useTabs = false;
 NeckoTriage.prototype.components = [
     "Networking",
     "Networking: Cache",
-    "Networking: Cookies",
     "Networking: DNS",
     "Networking: File",
     "Networking: HTTP",


### PR DESCRIPTION
Triage responsibility was moved to privacy team in [Bug 2049740](https://bugzilla.mozilla.org/show_bug.cgi?id=2049740)

Update triage tool to reflect handed-over triage responsibility.